### PR TITLE
minor fixes

### DIFF
--- a/functions_test.go
+++ b/functions_test.go
@@ -2,6 +2,7 @@ package surevego
 
 import (
 	"log"
+	"sync"
 	"testing"
 )
 
@@ -56,10 +57,13 @@ func TestLoadEveJSONFile(t *testing.T) {
 
 func TestLoadBrokenEveJSONFile(t *testing.T) {
 	var countErrors int
+	var wg sync.WaitGroup
 
 	ee, ec := LoadEveJSONFile("testdata/eve_broken.json")
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for err := range ec {
 			t.Log(err)
 			countErrors++
@@ -72,6 +76,7 @@ func TestLoadBrokenEveJSONFile(t *testing.T) {
 		}
 	}
 
+	wg.Wait()
 	if countErrors < 1 {
 		t.Error("Error count mismatch")
 	}

--- a/structs.go
+++ b/structs.go
@@ -213,6 +213,10 @@ type tcpEvent struct {
 	TCPflagsTs string `json:"tcp_flags_ts"`
 }
 
+type emailEvent struct {
+	Status string `json:"status"`
+}
+
 // EveEvent is the huge struct which can contain a parsed suricata eve.json
 // log event.
 type EveEvent struct {
@@ -244,11 +248,8 @@ type EveEvent struct {
 	// SMTP Events have some additional high level attributes to the json model
 	SMTP *smtpEvent `json:"smtp,omitempty"`
 
-	Email struct {
-		Status string `json:"status"`
-	} `json:"email,omitempty"`
-
 	// Other sub event_types
+	Email    *emailEvent    `json:"email,omitempty"`
 	DNS      *dnsEvent      `json:"dns,omitempty"`
 	HTTP     *httpEvent     `json:"http,omitempty"`
 	Fileinfo *fileinfoEvent `json:"fileinfo,omitempty"`

--- a/structs.go
+++ b/structs.go
@@ -15,10 +15,7 @@ func (t *suriTime) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	t.Time, err = time.Parse(suricataTimestampFormat, data)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 type alertEvent struct {


### PR DESCRIPTION
This PR introduces the following changes:
 - allow to marshal `EveEvent` JSON  without always ending up with an `email` object
 - please gosimple
 - fix data race for `countErrors` in test case