### PR TITLE
enable roundtrip to and from JSON

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -16,9 +16,12 @@ func LoadEveJSONFile(path string) (<-chan EveEvent, <-chan error) {
 
 	file, err := os.Open(path)
 	if err != nil {
-		errorChan <- err
-		close(eventChan)
-		close(errorChan)
+		go func() {
+			errorChan <- err
+			close(eventChan)
+			close(errorChan)
+		}()
+		return nil, errorChan
 	}
 
 	scanner := bufio.NewScanner(file)

--- a/functions_test.go
+++ b/functions_test.go
@@ -127,7 +127,7 @@ func TestMarshalWithTimestamp(t *testing.T) {
 		t.Error(err)
 	}
 
-	if inEVE.Timestamp.Time != e.Timestamp.Time {
+	if !inEVE.Timestamp.Time.Equal(e.Timestamp.Time) {
 		t.Fatalf("timestamp round-trip failed: %v <-> %v", inEVE.Timestamp, e.Timestamp)
 	}
 }

--- a/structs.go
+++ b/structs.go
@@ -18,6 +18,10 @@ func (t *suriTime) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+func (t *suriTime) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + t.Time.Format(suricataTimestampFormat) + "\""), nil
+}
+
 type alertEvent struct {
 	Action      string `json:"action"`
 	Gid         int    `json:"gid"`


### PR DESCRIPTION
Suricata's EVE uses a custom time format which requires a separate formatting string for parsing. If this format is not used during marshaling into JSON, a round-trip is not possible, and a JSON once marshaled can not be parsed again by surevego. Hence we need to also marshal the timestamp value in the same fashion.

This PR also increases the test coverage to 96.5%, also adding the necessary code to detect missing input files.